### PR TITLE
Alloc_ID fix

### DIFF
--- a/sky/scheduler/dbscheduler.py
+++ b/sky/scheduler/dbscheduler.py
@@ -1059,7 +1059,7 @@ class Scheduler:
         else:
             db_ret = self.ph_db.get_from_allocation(
                 ['designator', 'program_id'],
-                where_dict={'id': allocation_id})[0]
+                where_dict={'id': int(allocation_id)})[0]
             p60prid = db_ret[0]
             prog_id = db_ret[1]
             db_ret = self.ph_db.get_from_program(['name', 'PI'],


### PR DESCRIPTION
After another timeout issue, I've learned that the robot needs allocation id's in str format, but sedmpy needs it in int format, even though the database itself can use either. This is to alleviate that bit of miscommunication.